### PR TITLE
Add example to README of parsing 2 required args

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ static void Main(string[] args)
 }
 ```
 
-If you wish to see the usage type
+If you wish to see the usage run the application and pass it `/?` or `-?`:
 
 ```shell
 > validate /?

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here's an example usage:
 You can parse this with the following code:
 
 ```csharp
-static int Main(string[] args)
+static void Main(string[] args)
 {
   string jsonFile = null;
   string schemaFile = null;
@@ -39,6 +39,7 @@ static int Main(string[] args)
   if (!options.Parse(args) || jsonFile == null || schemaFile == null)
   {
     options.PrintUsage();
+    return;
   }
 
   // Use jsonFile and schemaFile in your app...

--- a/README.md
+++ b/README.md
@@ -12,6 +12,40 @@ Jmaxxz.Console.Shell ![Jmaxxz.Console.Shell](https://img.shields.io/nuget/v/Jmax
 PM> Install-Package Jmaxxz.Console.Shell 
 ```
 
+Examples
+-----
+Let's assume that we have an app that validates json against a json schema. Our app expects 2 files: the first file contains the json and the second file contains the json schema.
+
+Here's an example usage:
+
+    $ validate.exe JsonFile.json SchemaFile.schema
+
+You can parse this with the following code:
+
+```csharp
+static int Main(string[] args)
+{
+  string jsonFile = null;
+  string schemaFile = null;
+
+  var options = new Options
+  {
+    new Option(new string[] {}, s => jsonFile = s, "jsonFile",
+      "The file that contains the json you wish to validate"),
+    new Option(new string[] {}, s => schemaFile = s, "schemaFile",
+      "The file that contains the schema to use for validation")
+  }
+
+  if (!options.Parse(args) || jsonFile == null || schemaFile == null)
+  {
+    options.PrintUsage();
+  }
+
+  // Use jsonFile and schemaFile in your app...
+}
+```
+
+
 License
 -------
 Jmaxxz.Console is distributed under the following license:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ static int Main(string[] args)
       "The file that contains the json you wish to validate"),
     new Option(new string[] {}, s => schemaFile = s, "schemaFile",
       "The file that contains the schema to use for validation")
-  }
+  };
 
   if (!options.Parse(args) || jsonFile == null || schemaFile == null)
   {
@@ -45,6 +45,24 @@ static int Main(string[] args)
 }
 ```
 
+If you wish to see the usage type
+
+```shell
+> validate /?
+Usage: validate [-?] <jsonFile> <schemaFile>
+================================================================================
+Flags                              |  Descriptions
+________________________________________________________________________________
+-?                                 |  Prints usage for validate.vshost.exe
+--help                             |
+--------------------------------------------------------------------------------
+<jsonFile>                         |  The file that contains the json you wish t
+                                   |  o validate
+--------------------------------------------------------------------------------
+<schemaFile>                       |  The file that contains the schema to use f
+                                   |  or validation
+--------------------------------------------------------------------------------
+```
 
 License
 -------


### PR DESCRIPTION
I'm usually left a little confused how to use this library. Here is an example for the README. I plan to add one or two more that illustrate flags.
